### PR TITLE
Feat/jbash parser

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -5,6 +5,7 @@
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
         <option name="delegatedBuild" value="false" />
+        <option name="testRunner" value="PLATFORM" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">
           <set>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_22" default="true" project-jdk-name="openjdk-21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="openjdk-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -4,7 +4,7 @@
   <component name="FrameworkDetectionExcludesConfiguration">
     <file type="web" url="file://$PROJECT_DIR$" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="openjdk-21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_22" default="true" project-jdk-name="openjdk-21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Project Link: [https://github.com/jacobnickerson/jbash](https://github.com/jacob
 <!-- ACKNOWLEDGMENTS -->
 ## Acknowledgments
 
-* None so far!
+* [Best README Template](https://github.com/othneildrew/Best-README-Template/)
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@
     <img src="images/logo.png" alt="Logo" width="80" height="80">
   </a>
 
-<h3 align="center">project_title</h3>
+<h3 align="center">JBash</h3>
 
   <p align="center">
-    project_description
+    Java-Based BASH Clone (Jason Bourne Again SHell)
     <br />
     <br />
     <a href="https://github.com/jacobnickerson/jbash">View Demo</a>

--- a/README.md
+++ b/README.md
@@ -1,15 +1,3 @@
-<!-- Improved compatibility of back to top link: See: https://github.com/othneildrew/Best-README-Template/pull/73 -->
-<a id="readme-top"></a>
-<!--
-*** Thanks for checking out the Best-README-Template. If you have a suggestion
-*** that would make this better, please fork the repo and create a pull request
-*** or simply open an issue with the tag "enhancement".
-*** Don't forget to give the project a star!
-*** Thanks again! Now go create something AMAZING! :D
--->
-
-
-
 <!-- PROJECT SHIELDS -->
 <!--
 *** I'm using markdown "reference style" links for readability.
@@ -81,6 +69,7 @@
 <!-- ABOUT THE PROJECT -->
 ## About The Project
 
+TODO:
 [![Product Name Screen Shot][product-screenshot]](https://example.com)
 
 
@@ -114,7 +103,7 @@
 <!-- USAGE EXAMPLES -->
 ## Usage
 
-Use this space to show useful examples of how a project can be used. Additional screenshots, code examples and demos work well in this space. You may also link to more resources.
+TODO: Use this space to show useful examples of how a project can be used. Additional screenshots, code examples and demos work well in this space. You may also link to more resources.
 
 _For more examples, please refer to the [Documentation](https://example.com)_
 
@@ -169,7 +158,9 @@ Distributed under no license.
 <!-- CONTACT -->
 ## Contact
 
-Your Name - [@twitter_handle](https://twitter.com/twitter_handle) - jacobnickerson817@gmail.com
+Jacob Nickerson - [https://www.linkedin.com/in/jacobnickerson817/](https://www.linkedin.com/in/jacobnickerson817) - jacobnickerson817@gmail.com
+
+Chris Bloodsworth - [https://www.linkedin.com/in/chris-bloodsworth/](https://www.linkedin.com/in/chris-bloodsworth/) - christopherbloodsworth@gmail.com
 
 Project Link: [https://github.com/jacobnickerson/jbash](https://github.com/jacobnickerson/jbash)
 
@@ -180,9 +171,7 @@ Project Link: [https://github.com/jacobnickerson/jbash](https://github.com/jacob
 <!-- ACKNOWLEDGMENTS -->
 ## Acknowledgments
 
-* []() 
-* []()
-* []()
+* None so far!
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -201,7 +190,7 @@ Project Link: [https://github.com/jacobnickerson/jbash](https://github.com/jacob
 [license-shield]: https://img.shields.io/github/license/jacobnickerson/jbash.svg?style=for-the-badge
 [license-url]: https://github.com/jacobnickerson/jbash/blob/master/LICENSE.txt
 [linkedin-shield]: https://img.shields.io/badge/-LinkedIn-black.svg?style=for-the-badge&logo=linkedin&colorB=555
-[linkedin-url]: https://linkedin.com/in/jacobnickerson817/
+[linkedin-url]: https://linktr.ee/javabash
 [product-screenshot]: images/screenshot.png
 [Java.com]: https://img.shields.io/badge/Java-ED8B00?style=for-the-badge&logo=openjdk&logoColor=white
 [Java-url]:  https:://www.java.com/

--- a/src/main/java/jbash/Main.java
+++ b/src/main/java/jbash/Main.java
@@ -3,9 +3,14 @@ package jbash;
 
 import jbash.commands.Command;
 import jbash.commands.CommandFactory;
+import jbash.filesystem.FileSystemAPI;
+import jbash.filesystem.FileSystemObject;
+import jbash.filesystem.File;
+import jbash.filesystem.Directory;
 import jbash.parser.JBParserException;
 
 import java.util.ArrayList;
+import java.util.Optional;
 import java.util.Scanner;
 
 import static jbash.parser.JBashParser.parseCommand;
@@ -14,8 +19,10 @@ import static jbash.parser.JBashParser.parseCommand;
 public class Main {
     private static final Scanner userIn = new Scanner(System.in);
     private static final boolean debug = false;
+    private static final FileSystemAPI FSAPI = new FileSystemAPI();
 
     public static void main(String[] args) {
+
         while (true) {
             // Prompt
             System.out.print("[jbash]> ");

--- a/src/main/java/jbash/Main.java
+++ b/src/main/java/jbash/Main.java
@@ -30,7 +30,7 @@ public class Main {
 
             // Delete later: this just prints our tokens out
             if (debug) {
-                tokens.forEach(System.out::print);
+                tokens.forEach(t -> System.out.print("["+t+"]"));
                 System.out.println();
             }
 

--- a/src/main/java/jbash/Main.java
+++ b/src/main/java/jbash/Main.java
@@ -27,6 +27,7 @@ public class Main {
                 System.out.println(e.getMessage());
                 continue;
             }
+            if (tokens.isEmpty()) continue;
 
             // Delete later: this just prints our tokens out
             if (debug) {
@@ -35,7 +36,7 @@ public class Main {
             }
 
             // Gather command name
-            var cmdName = tokens.isEmpty() ? "" : tokens.getFirst();
+            var cmdName = tokens.getFirst();
 
             // Execute command with remaining arguments
             Command cmd = CommandFactory.get(cmdName);

--- a/src/main/java/jbash/Main.java
+++ b/src/main/java/jbash/Main.java
@@ -20,13 +20,13 @@ public class Main {
     private static final Scanner userIn = new Scanner(System.in);
     private static final boolean debug = false;
     private static FileSystemAPI FSAPI = FileSystemAPI.getInstance();
+    private static final char shell_prompt = '$';
 
     public static void main(String[] args) {
 
         while (true) {
             // Prompt
-            System.out.println("[jbash] " + (FSAPI.getCurrentDirectory().getPath()));
-            System.out.print("$ ");
+            System.out.print("[jbash] " + (FSAPI.getCurrentDirectory().getPath()) + " " + shell_prompt + " ");
 
             ArrayList<String> tokens;
             try { tokens = parseCommand(userIn.nextLine()); }

--- a/src/main/java/jbash/Main.java
+++ b/src/main/java/jbash/Main.java
@@ -19,13 +19,14 @@ import static jbash.parser.JBashParser.parseCommand;
 public class Main {
     private static final Scanner userIn = new Scanner(System.in);
     private static final boolean debug = false;
-    private static final FileSystemAPI FSAPI = new FileSystemAPI();
+    private static FileSystemAPI FSAPI = FileSystemAPI.getInstance();
 
     public static void main(String[] args) {
 
         while (true) {
             // Prompt
-            System.out.print("[jbash]> ");
+            System.out.println("[jbash] " + (FSAPI.getCurrentDirectory().getPath()));
+            System.out.print("$ ");
 
             ArrayList<String> tokens;
             try { tokens = parseCommand(userIn.nextLine()); }

--- a/src/main/java/jbash/commands/CmdCd.java
+++ b/src/main/java/jbash/commands/CmdCd.java
@@ -1,0 +1,4 @@
+package jbash.commands;
+
+public class CmdCd {
+}

--- a/src/main/java/jbash/commands/CmdCd.java
+++ b/src/main/java/jbash/commands/CmdCd.java
@@ -1,4 +1,29 @@
 package jbash.commands;
 
-public class CmdCd {
+import jbash.filesystem.FileSystemAPI;
+
+import java.util.List;
+
+public class CmdCd extends Command {
+    CmdCd(String name) {
+        super("cd");
+    }
+
+    @Override
+    public String getHelp() {
+        return "Usage: cd [directory]";
+    }
+
+    @Override
+    public int execute(List<String> args) {
+        if (args.size() > 1) { System.out.println("cd: too many arguments"); return 1; }
+        if (args.isEmpty()) {
+            FileSystemAPI.getInstance().moveCurrentDirectory("");
+            return 0;
+        }
+        if (FileSystemAPI.getInstance().moveCurrentDirectory(args.getFirst())) { return 0; }
+        // TODO: Add explicit error messaging
+        System.out.println("cd: cringe bro");
+        return 1;
+    }
 }

--- a/src/main/java/jbash/commands/CmdLs.java
+++ b/src/main/java/jbash/commands/CmdLs.java
@@ -1,0 +1,51 @@
+package jbash.commands;
+
+import jbash.filesystem.Directory;
+import jbash.filesystem.FileSystemAPI;
+import jbash.filesystem.FileSystemObject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+public class CmdLs extends Command {
+    CmdLs(String name) {
+        super("ls");
+    }
+
+    @Override
+    public String getHelp() {
+        return "Usage: ls [directory]";
+    }
+
+    @Override
+    public int execute(List<String> args) {
+        FileSystemAPI FSAPI = FileSystemAPI.getInstance();
+        boolean multiplePaths = false;
+        if (args.isEmpty()) {
+            List<FileSystemObject> currentFiles = FSAPI.getCurrentDirectory().getChildren();
+            for (FileSystemObject file : currentFiles) {
+                System.out.print(file.getName());
+                System.out.print(" ");
+            }
+            System.out.println();
+        } else {
+            if (args.size() > 1) { multiplePaths = true; }
+            for (String path : args) {
+                Optional<FileSystemObject> directory = FSAPI.getFileSystemObject(path);
+                if (directory.isEmpty()) { System.out.println("ls: cannot access '" + path + "': No such file or directory"); }
+                else if (!(directory.get() instanceof Directory)) { System.out.println(directory.get().getName()); }
+                else {
+                    List<FileSystemObject> children = ((Directory) directory.get()).getChildren();
+                    if (multiplePaths) { System.out.println(path + ":"); }
+                    for (FileSystemObject child : children) {
+                        System.out.print(child.getName());
+                        System.out.print(" ");
+                    }
+                    System.out.println();
+                }
+            }
+        }
+        return 0;
+    }
+}

--- a/src/main/java/jbash/commands/CmdLs.java
+++ b/src/main/java/jbash/commands/CmdLs.java
@@ -24,6 +24,7 @@ public class CmdLs extends Command {
         boolean multiplePaths = false;
         if (args.isEmpty()) {
             List<FileSystemObject> currentFiles = FSAPI.getCurrentDirectory().getChildren();
+            if (currentFiles.isEmpty()) { return 0; }
             for (FileSystemObject file : currentFiles) {
                 System.out.print(file.getName());
                 System.out.print(" ");

--- a/src/main/java/jbash/commands/CmdMkdir.java
+++ b/src/main/java/jbash/commands/CmdMkdir.java
@@ -1,0 +1,4 @@
+package jbash.commands;
+
+public class CmdMkdir {
+}

--- a/src/main/java/jbash/commands/CmdMkdir.java
+++ b/src/main/java/jbash/commands/CmdMkdir.java
@@ -1,4 +1,32 @@
 package jbash.commands;
 
-public class CmdMkdir {
+import jbash.filesystem.File;
+import jbash.filesystem.FileSystemAPI;
+
+import java.util.List;
+
+public class CmdMkdir extends Command {
+    CmdMkdir(String name) {
+        super("cd");
+    }
+
+    @Override
+    public String getHelp() {
+        return "Usage: mkdir [directory]";
+    }
+
+    @Override
+    public int execute(List<String> args) {
+        if (args.isEmpty()) {
+            System.out.println("mkdir: missing operand");
+            System.out.println("Try 'mkdir --help' for more information." );
+        }
+        FileSystemAPI FSAPI = FileSystemAPI.getInstance();
+        for (String arg : args) {
+            if (!FSAPI.createDirectory(arg)) {
+                System.out.println("mkdir: cannot create directory '" + arg + "'");
+            }
+        }
+        return 0;
+    }
 }

--- a/src/main/java/jbash/commands/CmdPwd.java
+++ b/src/main/java/jbash/commands/CmdPwd.java
@@ -1,4 +1,27 @@
 package jbash.commands;
 
-public class CmdPwd {
+import jbash.filesystem.Directory;
+import jbash.filesystem.FileSystemAPI;
+import jbash.filesystem.FileSystemObject;
+
+import java.util.List;
+import java.util.Optional;
+
+public class CmdPwd extends Command {
+    CmdPwd(String name) {
+        super("pwd");
+    }
+
+    @Override
+    public String getHelp() {
+        return "Usage: pwd";
+    }
+
+    @Override
+    public int execute(List<String> args) {
+        Optional<FileSystemObject> currentDirectoryOptional = FileSystemAPI.getInstance().getFileSystemObject("./");
+        if (currentDirectoryOptional.isEmpty() || !(currentDirectoryOptional.get() instanceof Directory currentDirectory)) { System.out.println("ERROR: I HAVE NO IDEA WHAT HAPPENED"); return 1; }
+        System.out.println(currentDirectory.getPath());
+        return 0;
+    }
 }

--- a/src/main/java/jbash/commands/CmdPwd.java
+++ b/src/main/java/jbash/commands/CmdPwd.java
@@ -1,0 +1,4 @@
+package jbash.commands;
+
+public class CmdPwd {
+}

--- a/src/main/java/jbash/commands/CommandFactory.java
+++ b/src/main/java/jbash/commands/CommandFactory.java
@@ -4,6 +4,9 @@ public class CommandFactory {
     public static Command get(String cmdName) {
         return switch (cmdName) {
             case "echo" -> new CmdEcho(cmdName);
+            case "pwd" -> new CmdPwd(cmdName);
+            case "cd" -> new CmdCd(cmdName);
+            case "mkdir" -> new CmdMkdir(cmdName);
             default -> new CmdUnknown(cmdName);
         };
     }

--- a/src/main/java/jbash/commands/CommandFactory.java
+++ b/src/main/java/jbash/commands/CommandFactory.java
@@ -7,6 +7,7 @@ public class CommandFactory {
             case "pwd" -> new CmdPwd(cmdName);
             case "cd" -> new CmdCd(cmdName);
             case "mkdir" -> new CmdMkdir(cmdName);
+            case "ls" -> new CmdLs(cmdName);
             default -> new CmdUnknown(cmdName);
         };
     }

--- a/src/main/java/jbash/filesystem/Directory.java
+++ b/src/main/java/jbash/filesystem/Directory.java
@@ -1,12 +1,25 @@
 package jbash.filesystem;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 public class Directory extends FileSystemObject {
-    private List<FileSystemObject> children;
-    private Directory parent;
+    private final List<FileSystemObject> children = new ArrayList<>();
 
-    public Directory(String name) {
-        super(name);
+    public Directory(String name, Directory parent) {
+        super(name, parent);
+    }
+
+    public void addChild(FileSystemObject fileSystemObject) {
+        children.add(fileSystemObject);
+    }
+
+    public void removeChild(FileSystemObject file) {
+        children.remove(file);
+    }
+
+    public Optional<FileSystemObject> findChild(String name) {
+        return children.stream().filter(FSO -> FSO.getName().equals(name)).findFirst();
     }
 }

--- a/src/main/java/jbash/filesystem/Directory.java
+++ b/src/main/java/jbash/filesystem/Directory.java
@@ -22,4 +22,8 @@ public class Directory extends FileSystemObject {
     public Optional<FileSystemObject> findChild(String name) {
         return children.stream().filter(FSO -> FSO.getName().equals(name)).findFirst();
     }
+
+    public List<FileSystemObject> getChildren() {
+        return this.children;
+    }
 }

--- a/src/main/java/jbash/filesystem/File.java
+++ b/src/main/java/jbash/filesystem/File.java
@@ -5,6 +5,7 @@ public class File extends FileSystemObject {
 
     public File(String name, Directory parent) {
         super(name, parent);
+        this.contents = "";
     }
 
     public File(String name, Directory parent, String contents) {

--- a/src/main/java/jbash/filesystem/File.java
+++ b/src/main/java/jbash/filesystem/File.java
@@ -1,10 +1,22 @@
 package jbash.filesystem;
 
 public class File extends FileSystemObject {
-    private Directory parent;
     private String contents;
 
-    public File(String name) {
-        super(name);
+    public File(String name, Directory parent) {
+        super(name, parent);
+    }
+
+    public File(String name, Directory parent, String contents) {
+        super(name, parent);
+        this.contents = contents;
+    }
+
+    public String getContents() {
+        return contents;
+    }
+
+    public void setContents(String newContents) {
+        this.contents = newContents;
     }
 }

--- a/src/main/java/jbash/filesystem/FileSystemAPI.java
+++ b/src/main/java/jbash/filesystem/FileSystemAPI.java
@@ -1,0 +1,91 @@
+package jbash.filesystem;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+public class FileSystemAPI {
+    private final Directory root;
+    private Directory currentDirectory;
+
+    public FileSystemAPI() {
+        this.root = new Directory("root", null);
+        this.currentDirectory = this.root;
+    }
+
+    public Optional<FileSystemObject> getFileSystemObject(String path) {
+        List<String> pathArgs = Arrays.stream(path.split("/")).filter(s -> !s.isEmpty()).toList();
+        Directory workingDirectory;
+        if (pathArgs.getFirst().equals(".")) {  // starting in current directory
+            workingDirectory = this.currentDirectory;
+        } else {
+            workingDirectory = this.root;
+        }
+        for (int i = 0; i < pathArgs.size(); i++) {
+            if (i < pathArgs.size() - 1) {
+                switch (pathArgs.get(i)) {
+                    case ".":
+                        continue;
+                    case "..":
+                        workingDirectory = workingDirectory.getParent();
+                        break;
+                    default:
+                        Optional<FileSystemObject> optionalFSO = workingDirectory.findChild(pathArgs.get(i));
+                        if (optionalFSO.isEmpty() || !(optionalFSO.get() instanceof Directory)) {
+                            return Optional.empty();
+                        } else {
+                            workingDirectory = (Directory) optionalFSO.get();
+                        }
+                }
+            } else {
+                return workingDirectory.findChild(pathArgs.get(i));
+            }
+        }
+        return Optional.empty();
+    }
+
+    public boolean moveFSO(String movedFSOPath, String newLocationPath) {
+        Optional<FileSystemObject> optionalMovedFSO = getFileSystemObject(movedFSOPath);
+        Optional<FileSystemObject> optionalNewDirectory = getFileSystemObject(newLocationPath);
+
+        if (optionalMovedFSO.isEmpty() || optionalNewDirectory.isEmpty()) { return false; }
+        FileSystemObject movedFSO = optionalMovedFSO.get();
+        FileSystemObject newDirectory = optionalNewDirectory.get();
+        if (!(newDirectory instanceof Directory newParent)) { return false; }
+        updateParent(movedFSO, newParent);
+        return true;
+    }
+
+    public boolean createFile(String name, Directory parent) {
+        if (parent == null || name.isEmpty()) { return false; }
+        File newFile = new File(name, parent);
+        parent.addChild(newFile);
+        return true;
+    }
+
+    public boolean createFile(String name, Directory parent, String contents) {
+        if (parent == null || name.isEmpty()) { return false; }
+        File newFile = new File(name, parent, contents);
+        parent.addChild(newFile);
+        return true;
+    }
+
+    public boolean createDirectory(String name, Directory parent) {
+        if (parent == null || name.isEmpty()) { return false; }
+        Directory newDirectory = new Directory(name, parent);
+        parent.addChild(newDirectory);
+        return true;
+    }
+
+    public Directory getRoot() {
+        return this.root;
+    }
+
+    private void updateParent(FileSystemObject FSO, Directory newParent) {
+        FSO.getParent().removeChild(FSO);
+        newParent.addChild(FSO);
+        FSO.setParent(newParent);
+        FSO.updatePath();
+    }
+
+}

--- a/src/main/java/jbash/filesystem/FileSystemAPI.java
+++ b/src/main/java/jbash/filesystem/FileSystemAPI.java
@@ -23,11 +23,9 @@ public class FileSystemAPI {
         this.FSAPI = new FileSystemAPI();
     }
 
-    // TODO: Add support for quotes
     public Optional<FileSystemObject> getFileSystemObject(String path) {
         if (path.isEmpty()) { return Optional.empty(); }
-        boolean directorySearch = false;
-        if (path.endsWith("/")) { directorySearch = true; }  // Paths ending in / can only reference directories
+        boolean directorySearch = path.endsWith("/"); // Paths ending in / can only reference directories
         List<String> pathArgs = Arrays.stream(path.split("/")).filter(s -> !s.isEmpty()).toList();
         if (pathArgs.isEmpty()) { return Optional.of(root); }
         Directory workingDirectory;

--- a/src/main/java/jbash/filesystem/FileSystemAPI.java
+++ b/src/main/java/jbash/filesystem/FileSystemAPI.java
@@ -3,14 +3,26 @@ package jbash.filesystem;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class FileSystemAPI {
     private final Directory root;
     private Directory currentDirectory;
 
-    public FileSystemAPI() {
+    private static FileSystemAPI FSAPI = new FileSystemAPI();
+
+    private FileSystemAPI() {
         this.root = new Directory("root", null);
         this.currentDirectory = this.root;
+    }
+
+    public static FileSystemAPI getInstance() {
+        return FSAPI;
+    }
+
+    public void reset() {
+        this.FSAPI = new FileSystemAPI();
     }
 
     // TODO: Add support for quotes
@@ -21,10 +33,10 @@ public class FileSystemAPI {
         List<String> pathArgs = Arrays.stream(path.split("/")).filter(s -> !s.isEmpty()).toList();
         if (pathArgs.isEmpty()) { return Optional.of(root); }
         Directory workingDirectory;
-        if (pathArgs.getFirst().equals(".")) {  // starting in current directory
-            workingDirectory = this.currentDirectory;
-        } else {
+        if (pathArgs.getFirst().equals("/")) {  // starting in root directory
             workingDirectory = this.root;
+        } else {
+            workingDirectory = this.currentDirectory;
         }
         for (int i = 0; i < pathArgs.size(); i++) {
             if (i < pathArgs.size() - 1) {
@@ -121,6 +133,19 @@ public class FileSystemAPI {
         return true;
     }
 
+    public boolean createDirectory(String path) {
+        // split name from the rest of the path
+        String strippedPath = path.replaceAll("[" + "/" + "]+$", "");
+        if (strippedPath.isEmpty()) { return false; }
+        int lastSlashIndex = strippedPath.lastIndexOf("/");
+        String parentPath;
+        if (lastSlashIndex == 0) { parentPath = "/"; }
+        else if (lastSlashIndex == -1) { parentPath = "./"; }
+        else { parentPath = strippedPath.substring(0, lastSlashIndex); }
+        String name = strippedPath.substring(lastSlashIndex+1);
+        return createDirectory(name, parentPath);
+    }
+
     public Directory getRoot() {
         return this.root;
     }
@@ -133,10 +158,15 @@ public class FileSystemAPI {
     }
 
     public boolean moveCurrentDirectory(String path) {
+        if (path.isEmpty()) { this.currentDirectory = this.root; return true; }  // TODO: Implement home directory and change this to navigate to it
         Optional<FileSystemObject> newDirectoryOptional = getFileSystemObject(path);
         if (newDirectoryOptional.isEmpty() || !(newDirectoryOptional.get() instanceof Directory)) { return false; }
         this.currentDirectory = (Directory) newDirectoryOptional.get();
         return true;
+    }
+
+    public Directory getCurrentDirectory() {
+        return this.currentDirectory;
     }
 
 }

--- a/src/main/java/jbash/filesystem/FileSystemAPI.java
+++ b/src/main/java/jbash/filesystem/FileSystemAPI.java
@@ -3,8 +3,6 @@ package jbash.filesystem;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 public class FileSystemAPI {
     private final Directory root;
@@ -145,6 +143,7 @@ public class FileSystemAPI {
         String name = strippedPath.substring(lastSlashIndex+1);
         return createDirectory(name, parentPath);
     }
+
 
     public Directory getRoot() {
         return this.root;

--- a/src/main/java/jbash/filesystem/FileSystemAPI.java
+++ b/src/main/java/jbash/filesystem/FileSystemAPI.java
@@ -13,8 +13,13 @@ public class FileSystemAPI {
         this.currentDirectory = this.root;
     }
 
+    // TODO: Add support for quotes
     public Optional<FileSystemObject> getFileSystemObject(String path) {
+        if (path.isEmpty()) { return Optional.empty(); }
+        boolean directorySearch = false;
+        if (path.endsWith("/")) { directorySearch = true; }  // Paths ending in / can only reference directories
         List<String> pathArgs = Arrays.stream(path.split("/")).filter(s -> !s.isEmpty()).toList();
+        if (pathArgs.isEmpty()) { return Optional.of(root); }
         Directory workingDirectory;
         if (pathArgs.getFirst().equals(".")) {  // starting in current directory
             workingDirectory = this.currentDirectory;
@@ -38,7 +43,16 @@ public class FileSystemAPI {
                         }
                 }
             } else {
-                return workingDirectory.findChild(pathArgs.get(i));
+                switch(pathArgs.get(i)) {
+                    case ".":
+                        return Optional.of(workingDirectory);
+                    case "..":
+                        return Optional.of(workingDirectory.getParent());
+                    default:
+                        Optional<FileSystemObject> foundObject = workingDirectory.findChild(pathArgs.get(i));
+                        if (directorySearch && (foundObject.isEmpty() || !(foundObject.get() instanceof Directory))) { return Optional.empty(); }
+                        return workingDirectory.findChild(pathArgs.get(i));
+                }
             }
         }
         return Optional.empty();
@@ -58,6 +72,16 @@ public class FileSystemAPI {
 
     public boolean createFile(String name, Directory parent) {
         if (parent == null || name.isEmpty()) { return false; }
+        if (parent.findChild(name).isPresent()) { return false; }
+        File newFile = new File(name, parent);
+        parent.addChild(newFile);
+        return true;
+    }
+
+    public boolean createFile(String name, String parentPath) {
+        Optional<FileSystemObject> parentOptional = getFileSystemObject(parentPath);
+        if (parentOptional.isEmpty() || !(parentOptional.get() instanceof Directory parent) || name.isEmpty()) { return false; }
+        if (parent.findChild(name).isPresent()) { return false; }
         File newFile = new File(name, parent);
         parent.addChild(newFile);
         return true;
@@ -65,6 +89,16 @@ public class FileSystemAPI {
 
     public boolean createFile(String name, Directory parent, String contents) {
         if (parent == null || name.isEmpty()) { return false; }
+        if (parent.findChild(name).isPresent()) { return false; }
+        File newFile = new File(name, parent, contents);
+        parent.addChild(newFile);
+        return true;
+    }
+
+    public boolean createFile(String name, String parentPath, String contents) {
+        Optional<FileSystemObject> parentOptional = getFileSystemObject(parentPath);
+        if (parentOptional.isEmpty() || !(parentOptional.get() instanceof Directory parent) || name.isEmpty()) { return false; }
+        if (parent.findChild(name).isPresent()) { return false; }
         File newFile = new File(name, parent, contents);
         parent.addChild(newFile);
         return true;
@@ -72,6 +106,16 @@ public class FileSystemAPI {
 
     public boolean createDirectory(String name, Directory parent) {
         if (parent == null || name.isEmpty()) { return false; }
+        if (parent.findChild(name).isPresent()) { return false; }
+        Directory newDirectory = new Directory(name, parent);
+        parent.addChild(newDirectory);
+        return true;
+    }
+
+    public boolean createDirectory(String name, String parentPath) {
+        Optional<FileSystemObject> parentOptional = getFileSystemObject(parentPath);
+        if (parentOptional.isEmpty() || !(parentOptional.get() instanceof Directory parent) || name.isEmpty()) { return false; }
+        if (parent.findChild(name).isPresent()) { return false; }
         Directory newDirectory = new Directory(name, parent);
         parent.addChild(newDirectory);
         return true;
@@ -86,6 +130,13 @@ public class FileSystemAPI {
         newParent.addChild(FSO);
         FSO.setParent(newParent);
         FSO.updatePath();
+    }
+
+    public boolean moveCurrentDirectory(String path) {
+        Optional<FileSystemObject> newDirectoryOptional = getFileSystemObject(path);
+        if (newDirectoryOptional.isEmpty() || !(newDirectoryOptional.get() instanceof Directory)) { return false; }
+        this.currentDirectory = (Directory) newDirectoryOptional.get();
+        return true;
     }
 
 }

--- a/src/main/java/jbash/filesystem/FileSystemObject.java
+++ b/src/main/java/jbash/filesystem/FileSystemObject.java
@@ -1,11 +1,44 @@
 package jbash.filesystem;
 
-import java.nio.file.FileSystem;
-
 public abstract class FileSystemObject {
-    private final String name;
+    private String name;
+    private Directory parent;
+    private String path;
 
-    public FileSystemObject(String name) {
+    public FileSystemObject(String name, Directory parent) {
         this.name = name;
+        if (parent == null) {
+            this.parent = (Directory) this;
+            this.path = "/";
+        } else {
+            this.parent = parent;
+            updatePath();
+        }
+    }
+
+    public String getPath() {
+        return this.path;
+    }
+
+    public Directory getParent() {
+        return this.parent;
+    }
+
+    public void updatePath() {
+        // check if parent is root
+        if (this.getParent().getParent() == this.getParent()) { this.path = "/" + name; }
+        else { this.path = parent.getPath() + "/" + name; }
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String newName) {
+        this.name = newName;
+    }
+
+    public void setParent(Directory newParent) {
+       this.parent = newParent;
     }
 }

--- a/src/main/java/jbash/filesystem/JBashFileSystem.java
+++ b/src/main/java/jbash/filesystem/JBashFileSystem.java
@@ -1,5 +1,0 @@
-package jbash.filesystem;
-
-public class JBashFileSystem {
-
-}

--- a/src/main/java/jbash/jbashutils/JBashUtils.java
+++ b/src/main/java/jbash/jbashutils/JBashUtils.java
@@ -7,8 +7,19 @@ import java.util.stream.Collectors;
 
 public class JBashUtils {
     public record FindResult(String str, Integer index) {};
+
+    /**
+     * Searches <code>haystack</code> starting at <code>startIndex</code> for any occurrence
+     * of a string in <code>needles</code> and returns the first match as a <code>FindResult</code>.
+     * If no match exists, <code>("",-1)</code> is returned.
+     *
+     * @param haystack String to perform search in.
+     * @param startIndex Index to begin the search from.
+     * @param needles Strings to find in <code>haystack</code>.
+     * @return FindResult of the first match, or <code>("", -1)</code> if none exist.
+     */
     public static FindResult findFirstOf(String haystack, int startIndex, String... needles) {
-        if (needles.length == 0) {
+        if (needles == null || needles.length == 0) {
             throw new RuntimeException("Improper use of findFirstOf: needles.length() must be greater than 0");
         }
 
@@ -17,5 +28,9 @@ public class JBashUtils {
                 .map(needle -> new FindResult(needle, haystack.indexOf(needle, startIndex)))
                 .filter(result -> result.index != -1)
                 .reduce(new FindResult("", -1), (a,b) -> a.index < b.index ? a : b);
+    }
+    // StringBuilder variant
+    public static FindResult findFirstOf(StringBuilder haystack, int startIndex, String... needles) {
+        return findFirstOf(String.valueOf(haystack), startIndex, needles);
     }
 }

--- a/src/main/java/jbash/jbashutils/JBashUtils.java
+++ b/src/main/java/jbash/jbashutils/JBashUtils.java
@@ -27,7 +27,7 @@ public class JBashUtils {
                 .parallelStream()
                 .map(needle -> new FindResult(needle, haystack.indexOf(needle, startIndex)))
                 .filter(result -> result.index != -1)
-                .reduce(new FindResult("", -1), (a,b) -> a.index < b.index ? a : b);
+                .reduce(new FindResult("", -1), (a,b) -> a.index < b.index && a.index != -1 ? a : b);
     }
     // StringBuilder variant
     public static FindResult findFirstOf(StringBuilder haystack, int startIndex, String... needles) {

--- a/src/main/java/jbash/jbashutils/JBashUtils.java
+++ b/src/main/java/jbash/jbashutils/JBashUtils.java
@@ -2,7 +2,20 @@ package jbash.jbashutils;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class JBashUtils {
+    public record FindResult(String str, Integer index) {};
+    public static FindResult findFirstOf(String haystack, int startIndex, String... needles) {
+        if (needles.length == 0) {
+            throw new RuntimeException("Improper use of findFirstOf: needles.length() must be greater than 0");
+        }
 
+        return List.of(needles)
+                .parallelStream()
+                .map(needle -> new FindResult(needle, haystack.indexOf(needle, startIndex)))
+                .filter(result -> result.index != -1)
+                .reduce(new FindResult("", -1), (a,b) -> a.index < b.index ? a : b);
+    }
 }

--- a/src/main/java/jbash/parser/JBashParser.java
+++ b/src/main/java/jbash/parser/JBashParser.java
@@ -170,7 +170,7 @@ public final class JBashParser {
      * Will return a token of TokenKind.EOF if no more tokens are available.
      * @return next Token in input stream
      */
-    public Token nextToken() throws JBParserException {
+    private Token nextToken() throws JBParserException {
         return switch(peek()) {
             case '\n' -> new Token(TokenType.EOF, start, "");
             case '\\' -> {
@@ -252,7 +252,14 @@ public final class JBashParser {
             if (start != 0 && str.charAt(start - 1) == '\\') {
                 continue;
             }
-            int end = str.indexOf(quote, i);
+
+            // loop until we find a non-escaped quote
+            int end;
+            while (true) {
+                end = str.indexOf(quote, i);
+                if (end == -1 || str.charAt(end - 1) != '\\') break;
+                else i = end + 1;
+            }
             if (end == -1) {
                 // TODO: this should not throw an error, but rather begin a new line of input
                 throw new JBParserException(JBParserException.msgNoMatching(quote.charAt(0), 1));

--- a/src/main/java/jbash/parser/JBashParser.java
+++ b/src/main/java/jbash/parser/JBashParser.java
@@ -158,7 +158,7 @@ public final class JBashParser {
 
                 current--;
                 consume();
-                yield nextToken();
+                yield new Token(TokenType.Whitespace, start, "\0");
             }
             case '$' -> new Token(TokenType.Dollar, start, consume());
             case '\'' -> {
@@ -243,10 +243,11 @@ public final class JBashParser {
             tokens.add(t);
         } while (tokens.getLast().type() != TokenType.EOF);
 
-        return tokens.stream()
-                     .map(Token::lexeme)
-                     .filter(tok -> !tok.isEmpty())
-                     .collect(Collectors.toCollection(ArrayList::new));
+        return new ArrayList<>(
+                List.of(tokens.parallelStream()
+                        .map(Token::lexeme)
+                        .reduce("", (s, t) -> s + t)
+                        .split("\0")));
     }
 
 }

--- a/src/main/java/jbash/parser/JBashParser.java
+++ b/src/main/java/jbash/parser/JBashParser.java
@@ -7,9 +7,9 @@ import java.util.stream.Collectors;
 public final class JBashParser {
     private static final char[] specialChars =
             {'{', '}', '[', ']', '(', ')', '$', ' '};
-    private StringBuilder str;         // Content string we are trying to parse
-    private int start;          // Start of the current consumed lexeme
-    private int current;        // Current character we are inspecting
+    private final StringBuilder str;  // Content string we are trying to parse
+    private int start;                // Start of the current consumed lexeme
+    private int current;              // Current character we are inspecting
 
 
     JBashParser(String str) {
@@ -206,7 +206,8 @@ public final class JBashParser {
         // Each loop, we process a pair of double quotes.
         int i = 0;  // Index of the last seen double quote.
         while (str.indexOf("\"", i) != -1) {
-            int start = str.indexOf("\"");
+            int start = str.indexOf("\"", i);
+            i = start + 1;
 
             // Escaped quotes aren't real, skip em
             if (start != 0 && str.charAt(start - 1) == '\\') {
@@ -217,6 +218,7 @@ public final class JBashParser {
                 // TODO: this should not throw an error, but rather begin a new line of input
                 throw new JBParserException(JBParserException.msgNoMatching('"', 1));
             }
+            i = end + 1;
 
             // Pull out the content for processing, delete it from the original string
             var content = str.substring(start+1, end);
@@ -229,9 +231,6 @@ public final class JBashParser {
             str.insert(start+1, content);
             str.setCharAt(start, '\'');  // This is our way of escaping the string contents
             str.setCharAt(end, '\'');    // Since single-quoted strings content is always escaped
-
-            // Increment counter
-            i = end + 1;
         }
     }
 

--- a/src/main/java/jbash/parser/TokenType.java
+++ b/src/main/java/jbash/parser/TokenType.java
@@ -8,5 +8,7 @@ public enum TokenType {
     CurlyExpr,          // {Curly Expression}
     BrackExpr,          // [Bracket Expression]
     Dollar,             // $
-    EOF, Whitespace,                // END OF FILE
+    EOF,                // END OF FILE
+    EOL,                // END OF LINE
+    Whitespace,         // whitespace.
 }

--- a/src/main/java/jbash/parser/TokenType.java
+++ b/src/main/java/jbash/parser/TokenType.java
@@ -8,5 +8,5 @@ public enum TokenType {
     CurlyExpr,          // {Curly Expression}
     BrackExpr,          // [Bracket Expression]
     Dollar,             // $
-    EOF,                // END OF FILE
+    EOF, Whitespace,                // END OF FILE
 }

--- a/src/main/java/jbash/parser/TokenType.java
+++ b/src/main/java/jbash/parser/TokenType.java
@@ -8,6 +8,28 @@ public enum TokenType {
     CurlyExpr,          // {Curly Expression}
     BrackExpr,          // [Bracket Expression]
     Dollar,             // $
+    AndIf,
+    OrIf,
+    DSemi,
+    DLess,
+    DGreat,
+    LessAnd,
+    GreatAnd,
+    LessGreat,
+    DLessDash,
+    Clobber,
+    If,
+    Then,
+    Else,
+    Elif,
+    Fi,
+    Do,
+    Done,
+    Case,
+    Esac,
+    While,
+    Until,
+    For,
     EOF,                // END OF FILE
     EOL,                // END OF LINE
     Whitespace,         // whitespace.

--- a/src/test/java/jbash/FileSystemTests.java
+++ b/src/test/java/jbash/FileSystemTests.java
@@ -1,59 +1,116 @@
 package jbash;
 
+import jbash.filesystem.Directory;
+import jbash.filesystem.File;
+import jbash.filesystem.FileSystemAPI;
+import jbash.filesystem.FileSystemObject;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static jbash.parser.JBashParser.parseCommand;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class FileSystemTests {
+    FileSystemAPI FSAPI;
+    Directory root;
+
+    @BeforeEach
+    public void setupFSAPI() {
+        FSAPI = new FileSystemAPI();
+        root = FSAPI.getRoot();
+    }
+
+    @Test
+    void testMakeFileNoName() {
+        assertFalse(FSAPI.createFile("", root), "File created with no name");
+    }
+
+    @Test
+    void testMakeFileDuplicateFile() {
+        FSAPI.createFile("test", root);
+        assertFalse(FSAPI.createFile("test", root), "File created with duplicate name");
+    }
+
+    @Test
+    void testMakeFile() {
+        Assertions.assertTrue(FSAPI.createFile("test", root), "File not created");
+    }
+
+    @Test
+    void testFindChildFile() {
+        FSAPI.createFile("test", root);
+        Optional<FileSystemObject> child = root.findChild("test");
+        Assertions.assertTrue(child.isPresent(), "Child not found");
+        assertInstanceOf(File.class, child.get(), "Child is not a File");
+    }
+
+    @Test
+    void testGetPath() {
+        Assertions.assertEquals(root.getPath(), "/", "Root file path does not equal '/'");
+        FSAPI.createFile("test", root);
+        Optional<FileSystemObject> child = root.findChild("test");
+        Assertions.assertTrue(child.isPresent(), "Child not found");
+        Assertions.assertEquals(child.get().getPath(), "/test", "Child file path is not '/test'");
+    }
+
+    @Test
+    void testMakeFileContents() {
+        FSAPI.createFile("test", root, "Nice contents!");
+        Optional<FileSystemObject> child = root.findChild("test");
+        Assertions.assertTrue(child.isPresent(), "File not found.");
+        File file = (File) child.get();
+        Assertions.assertEquals(file.getContents(), "Nice contents!", "File contents not equal");
+    }
+
+    @Test
+    void testFindChildDirectory() {
+        FSAPI.createDirectory("test", root);
+        Optional<FileSystemObject> child = root.findChild("test");
+        Assertions.assertTrue(child.isPresent(), "Child not found");
+        Assertions.assertInstanceOf(Directory.class, child.get(), "Child is not a Directory");
+    }
+
+    @Test
+    void testMakeFileInDirectory() {
+        FSAPI.createDirectory("test", root);
+        Optional<FileSystemObject> testDirectory = root.findChild("test");
+        Assertions.assertTrue(testDirectory.isPresent(), "Test directory not found");
+        Assertions.assertInstanceOf(Directory.class, testDirectory.get(), "Test directory is not a directory");
+        Directory directory = (Directory) testDirectory.get();
+        FSAPI.createFile("testFile", directory);
+        Optional<FileSystemObject> child2 = directory.findChild("testFile");
+        Assertions.assertTrue(child2.isPresent(), "Child not found");
+        Assertions.assertInstanceOf(File.class, child2.get(), "Child is not a File");
+    }
+
+    @Test
+    void testMoveFile() {
+       FSAPI.createDirectory("testDirectory", root);
+        Optional<FileSystemObject> testDirectoryOptional = root.findChild("testDirectory");
+        Assertions.assertTrue(testDirectoryOptional.isPresent(), "Test directory not found");
+        Directory testDirectory = (Directory) testDirectoryOptional.get();
+        Assertions.assertInstanceOf(Directory.class, testDirectory, "Test directory is not a directory");
+        FSAPI.createFile("testFile", root);
+        Optional<FileSystemObject> testFile = root.findChild("testFile");
+        FSAPI.moveFSO(testFile.get().getPath(), testDirectory.getPath());
+        Assertions.assertEquals(testFile.get().getPath(), "/testDirectory/testFile", "Path incorrect");
+        Assertions.assertEquals(testFile.get().getParent(), testDirectory, "Test file does not belong to testDirectory");
+        Optional<FileSystemObject> testFileFound = testDirectory.findChild("testFile");
+        Assertions.assertTrue(testFileFound.isPresent(), "Test file not found in new directory children");
+        Optional<FileSystemObject> testFileFound2 = root.findChild("testFile");
+        Assertions.assertFalse(testFileFound2.isPresent(), "Test file is still found in root directory");
+    }
+
     @Nested
-    class GetFilePath {
-        @ParameterizedTest
-        @MethodSource
-        public void testGetFilePath(String name, String command, Object expected) {
-            test(command, expected);
-        }
-
-        public static Stream<Arguments> testGetFilePath() {
-            return Stream.of(
-                    Arguments.of(
-                            "Single Word",              // Test case name
-                            "april",                    // Input
-                            List.of("april")),          // Expected output
-                    Arguments.of(
-                            "Multiple Words",
-                            "april and june",
-                            List.of("april", "and", "june")),
-                    Arguments.of(
-                            "No Words",
-                            "",
-                            List.of())
-            );
-        }
-
-        private static void test(String input, Object expected) {
-            if (expected != null) {
-                try {
-                    // Some file-system setup and test
-                    var result = "TODO: result of some computation";
-                    Assertions.assertEquals(expected, result);
-                } catch (Exception e) {
-                    Assertions.fail(e);
-                }
-            }
-            // We use "null" as a value for when we expect a parse to fail.
-            // Expect it to throw some kind of exception.
-            else {
-                Assertions.assertThrows(Exception.class, () -> {
-                    // Some file system setup and test that we expect to throw an error
-                });
-            }
-        }
+    class testFileSystemObjects {
     }
 }

--- a/src/test/java/jbash/FileSystemTests.java
+++ b/src/test/java/jbash/FileSystemTests.java
@@ -25,7 +25,8 @@ public class FileSystemTests {
 
     @BeforeEach
     public void setupFSAPI() {
-        FSAPI = new FileSystemAPI();
+        FSAPI = FileSystemAPI.getInstance();
+        FSAPI.reset();
         root = FSAPI.getRoot();
     }
 
@@ -51,9 +52,22 @@ public class FileSystemTests {
     }
 
     @Test
-    void testMakeDirectoryWithPath() {
+    void testMakeDirectoryWithPathAndName() {
        Assertions.assertTrue(FSAPI.createDirectory("testFolder", "/"), "Directory not created in root");
        Assertions.assertTrue(FSAPI.createDirectory("testFolder", "/testFolder"), "Directory not created inside testFolder");
+    }
+
+    @Test
+    void testMakeDirectoryWithPath() {
+        Assertions.assertTrue(FSAPI.createDirectory("/testFolder"));
+        Optional<FileSystemObject> testDirectory = FSAPI.getFileSystemObject("/testFolder");
+        Assertions.assertTrue(testDirectory.isPresent(), "Test folder in root not found.");
+        Assertions.assertEquals(testDirectory.get().getPath(), "/testFolder", "Test folder path incorrect");
+
+        Assertions.assertTrue(FSAPI.createDirectory("/testFolder/testFolder2/"));
+        Optional<FileSystemObject> testDirectory2 = FSAPI.getFileSystemObject("/testFolder/testFolder2");
+        Assertions.assertTrue(testDirectory2.isPresent(), "Test folder in test folder 1 not found.");
+        Assertions.assertEquals(testDirectory2.get().getPath(), "/testFolder/testFolder2", "Test folder 2 path incorrect");
     }
 
     @Test
@@ -247,6 +261,7 @@ public class FileSystemTests {
         Assertions.assertTrue(testDirectoryOptional.isPresent() && testDirectoryOptional.get() instanceof Directory, "testFolder not found");
         Directory testDirectory = (Directory) testDirectoryOptional.get();
 
+        Assertions.assertTrue(FSAPI.moveCurrentDirectory(""), "Failed to move to home directory");
         Assertions.assertFalse(FSAPI.moveCurrentDirectory("sdahfk"), "Moved to a non-existing folder");
         Assertions.assertTrue(FSAPI.moveCurrentDirectory("/testFolder"), "Failed to move to testFolder");
         Assertions.assertEquals(testDirectory, FSAPI.getFileSystemObject("./").get(), "Current directory not equal to testFolder after moving to testFolder");

--- a/src/test/java/jbash/FileSystemTests.java
+++ b/src/test/java/jbash/FileSystemTests.java
@@ -31,13 +31,13 @@ public class FileSystemTests {
 
     @Test
     void testMakeFileNoName() {
-        assertFalse(FSAPI.createFile("", root), "File created with no name");
+        Assertions.assertFalse(FSAPI.createFile("", root), "File created with no name");
     }
 
     @Test
     void testMakeFileDuplicateFile() {
         FSAPI.createFile("test", root);
-        assertFalse(FSAPI.createFile("test", root), "File created with duplicate name");
+        Assertions.assertFalse(FSAPI.createFile("test", root), "File created with duplicate name");
     }
 
     @Test
@@ -46,16 +46,34 @@ public class FileSystemTests {
     }
 
     @Test
+    void testMakeDirectory() {
+        Assertions.assertTrue(FSAPI.createDirectory("testFolder", root), "Directory not created");
+    }
+
+    @Test
+    void testMakeDirectoryWithPath() {
+       Assertions.assertTrue(FSAPI.createDirectory("testFolder", "/"), "Directory not created in root");
+       Assertions.assertTrue(FSAPI.createDirectory("testFolder", "/testFolder"), "Directory not created inside testFolder");
+    }
+
+    @Test
+    void testMakeFileWithPath() {
+        Assertions.assertTrue(FSAPI.createFile("testFile", "/"), "File not created in root");
+        Assertions.assertTrue(FSAPI.createDirectory("testFolder", "/"), "Directory not created in root");
+        Assertions.assertTrue(FSAPI.createFile("testFile2", "/"), "File not created in testFolder");
+    }
+
+    @Test
     void testFindChildFile() {
         FSAPI.createFile("test", root);
         Optional<FileSystemObject> child = root.findChild("test");
         Assertions.assertTrue(child.isPresent(), "Child not found");
-        assertInstanceOf(File.class, child.get(), "Child is not a File");
+        Assertions.assertInstanceOf(File.class, child.get(), "Child is not a File");
     }
 
     @Test
     void testGetPath() {
-        Assertions.assertEquals(root.getPath(), "/", "Root file path does not equal '/'");
+        Assertions.assertEquals(root.getPath(), "/", "Root file path is not  '/'");
         FSAPI.createFile("test", root);
         Optional<FileSystemObject> child = root.findChild("test");
         Assertions.assertTrue(child.isPresent(), "Child not found");
@@ -110,7 +128,127 @@ public class FileSystemTests {
         Assertions.assertFalse(testFileFound2.isPresent(), "Test file is still found in root directory");
     }
 
-    @Nested
-    class testFileSystemObjects {
+    @Test
+    void testWriteContentsToFile() {
+        FSAPI.createFile("testFile", root, "Hello world!");
+        Optional<FileSystemObject> testFileFound = root.findChild("testFile");
+        Assertions.assertTrue(testFileFound.isPresent() && testFileFound.get() instanceof File, "File not found");
+        File testFile = (File) testFileFound.get();
+        Assertions.assertEquals(testFile.getContents(), "Hello world!", "Contents not set correctly");
+        testFile.setContents("New contents!");
+        Assertions.assertEquals(testFile.getContents(), "New contents!", "Contents not changed");
+    }
+
+    @Test
+    void testGetFileSystemObjectWithPath() {
+        FSAPI.createFile("testFile", root, "Hello world!");
+        FSAPI.createDirectory("testFolder", root);
+
+        Optional<FileSystemObject> testFileOptional = FSAPI.getFileSystemObject("/testFile");
+        Assertions.assertTrue(testFileOptional.isPresent(), "Test file not found");
+        Assertions.assertInstanceOf(File.class, testFileOptional.get(), "Test file is not a file");
+
+        Optional<FileSystemObject> testDirectoryOptional = FSAPI.getFileSystemObject("/testFolder");
+        Assertions.assertTrue(testDirectoryOptional.isPresent(), "Test folder not found");
+        Assertions.assertInstanceOf(Directory.class, testDirectoryOptional.get(), "Test folder is not a directory");
+
+        FSAPI.moveFSO("/testFile", "/testFolder");
+        Optional<FileSystemObject> testFileOptional2 = FSAPI.getFileSystemObject("/testFolder/testFile");
+        Assertions.assertTrue(testFileOptional2.isPresent(), "Test file not found after move");
+        Assertions.assertInstanceOf(File.class, testFileOptional.get(), "Test file is not a file after move");
+    }
+
+    @Test
+    void testGetFileSystemObjectPathParsing() {
+        FSAPI.createDirectory("testFolder", root);
+        Optional<FileSystemObject> testFolderOptional = FSAPI.getFileSystemObject("/testFolder");
+        Assertions.assertTrue(testFolderOptional.isPresent() && testFolderOptional.get() instanceof Directory, "Test directory not found");
+        Directory testFolder = (Directory) testFolderOptional.get();
+        FSAPI.createDirectory("testFolder2", testFolder);
+        FSAPI.createDirectory("test Folder 3", testFolder);
+        FSAPI.createFile("testFile", testFolder);
+        Optional<FileSystemObject> testFolder3Optional = FSAPI.getFileSystemObject("/testFolder/test Folder 3");
+        Assertions.assertTrue(testFolder3Optional.isPresent() && testFolder3Optional.get() instanceof Directory, "Test directory 3 not found");
+        Directory testFolder3 = (Directory) testFolder3Optional.get();
+        FSAPI.createFile("testFile2", testFolder3);
+
+        Optional<FileSystemObject> emptyPath = FSAPI.getFileSystemObject("");
+        Assertions.assertFalse(emptyPath.isPresent(), "FSO found with empty path");
+
+        Optional<FileSystemObject> rootOptional = FSAPI.getFileSystemObject("/");
+        Assertions.assertTrue(rootOptional.isPresent(), "Root not found by path");
+
+        Optional<FileSystemObject> rootOptional2 = FSAPI.getFileSystemObject("///////////////////////////");
+        Assertions.assertTrue(rootOptional2.isPresent(), "Root not found by multi slash path");
+
+        Optional<FileSystemObject> rootOptional3 = FSAPI.getFileSystemObject("./");
+        Assertions.assertTrue(rootOptional3.isPresent(), "Root not found by current directory");
+
+        Optional<FileSystemObject> testFileOptional = FSAPI.getFileSystemObject("/testFolder/testFile");
+        Assertions.assertTrue(testFileOptional.isPresent(), "Test file not found with absolute path");
+
+        Optional<FileSystemObject> testFileOptional2 = FSAPI.getFileSystemObject("./testFolder/testFile");
+        Assertions.assertTrue(testFileOptional2.isPresent(), "Test file not found with path starting at current directory");
+
+        Optional<FileSystemObject> testFileOptional3 = FSAPI.getFileSystemObject("//testFolder//testFile");
+        Assertions.assertTrue(testFileOptional3.isPresent(), "Test file not found with path containing double slashes");
+
+        Optional<FileSystemObject> testFileOptional4 = FSAPI.getFileSystemObject("/testFolder/../testFolder/testFile");
+        Assertions.assertTrue(testFileOptional4.isPresent(), "Test file not found with path traveling back with ..");
+
+        Optional<FileSystemObject> testFileOptional5 = FSAPI.getFileSystemObject("/testFolder/testFolder2/../testFile");
+        Assertions.assertTrue(testFileOptional5.isPresent(), "Test file not found traveling forward two directories then backwards one using ..");
+
+        Optional<FileSystemObject> testFileOptional6 = FSAPI.getFileSystemObject("./../../testFolder/testFolder2/..//.//.//.//.//testFile");
+        Assertions.assertTrue(testFileOptional6.isPresent(), "Test file not found doing some nonsense");
+
+        Optional<FileSystemObject> testFileOptional7 = FSAPI.getFileSystemObject("/testFolder/test Folder 3/testFile2");
+        Assertions.assertTrue(testFileOptional7.isPresent(), "Test file not found with path containing spaces");
+
+        Optional<FileSystemObject> testFileOptional8 = FSAPI.getFileSystemObject("/testFolder/testFile/");
+        Assertions.assertFalse(testFileOptional8.isPresent(), "Test file found with path ending in slash");
+
+        Optional<FileSystemObject> testDirectoryOptional = FSAPI.getFileSystemObject("/testFolder");
+        Assertions.assertFalse(testDirectoryOptional.isPresent(), "Test directory not found with path not ending in a slash");
+
+        Optional<FileSystemObject> testDirectoryOptional2 = FSAPI.getFileSystemObject("/testFolder");
+        Assertions.assertFalse(testDirectoryOptional2.isPresent(), "Test directory not found with path ending in a slash");
+    }
+
+    @Test
+    void testGetFileSystemObjectQuotes() {
+        FSAPI.createDirectory("testFolder", root);
+        FSAPI.createDirectory("test Folder 2", root);
+        Assertions.assertTrue(FSAPI.createFile("testFile", "/testFolder"), "testFile not created");
+        Assertions.assertTrue(FSAPI.createFile("testFile2", "/test Folder 2"), "testFile2 not created");
+
+        Optional<FileSystemObject> testFileOptional = FSAPI.getFileSystemObject("/testFolder/\"testFile\"");
+        Assertions.assertTrue(testFileOptional.isPresent(), "Test file not found with surround quotations and no spaces");
+
+        Optional<FileSystemObject> testFileOptional2 = FSAPI.getFileSystemObject("/testFolder/\"test\"File");
+        Assertions.assertTrue(testFileOptional2.isPresent(), "Test file not found with mid string quotations and no spaces");
+
+        Optional<FileSystemObject> testFileOptional3 = FSAPI.getFileSystemObject("/\"test Folder 2\"/testFile");
+        Assertions.assertTrue(testFileOptional3.isPresent(), "Test file not found with surrounding quotations and spaces");
+
+        Optional<FileSystemObject> testFileOptional4 = FSAPI.getFileSystemObject("/\"test\" Folder 2/testFile");
+        Assertions.assertTrue(testFileOptional4.isPresent(), "Test file not found with mid string quotations and spaces");
+    }
+
+    @Test
+    void testMoveCurrentDirectory() {
+        FSAPI.createDirectory("testFolder", "/");
+        FSAPI.createDirectory("testFolder2", "/testFolder");
+        FSAPI.createDirectory("testFolder3", "/testFolder/testFolder2");
+        Assertions.assertEquals(root, FSAPI.getFileSystemObject("/").get(), "Root does not equal root when found with path");
+        Assertions.assertEquals(root, FSAPI.getFileSystemObject("./").get(), "Root does not equal current directory before moving");
+
+        Optional<FileSystemObject> testDirectoryOptional = FSAPI.getFileSystemObject("/testFolder/");
+        Assertions.assertTrue(testDirectoryOptional.isPresent() && testDirectoryOptional.get() instanceof Directory, "testFolder not found");
+        Directory testDirectory = (Directory) testDirectoryOptional.get();
+
+        Assertions.assertFalse(FSAPI.moveCurrentDirectory("sdahfk"), "Moved to a non-existing folder");
+        Assertions.assertTrue(FSAPI.moveCurrentDirectory("/testFolder"), "Failed to move to testFolder");
+        Assertions.assertEquals(testDirectory, FSAPI.getFileSystemObject("./").get(), "Current directory not equal to testFolder after moving to testFolder");
     }
 }

--- a/src/test/java/jbash/FileSystemTests.java
+++ b/src/test/java/jbash/FileSystemTests.java
@@ -223,10 +223,10 @@ public class FileSystemTests {
         Assertions.assertFalse(testFileOptional8.isPresent(), "Test file found with path ending in slash");
 
         Optional<FileSystemObject> testDirectoryOptional = FSAPI.getFileSystemObject("/testFolder");
-        Assertions.assertFalse(testDirectoryOptional.isPresent(), "Test directory not found with path not ending in a slash");
+        Assertions.assertTrue(testDirectoryOptional.isPresent(), "Test directory not found with path not ending in a slash");
 
-        Optional<FileSystemObject> testDirectoryOptional2 = FSAPI.getFileSystemObject("/testFolder");
-        Assertions.assertFalse(testDirectoryOptional2.isPresent(), "Test directory not found with path ending in a slash");
+        Optional<FileSystemObject> testDirectoryOptional2 = FSAPI.getFileSystemObject("/testFolder/");
+        Assertions.assertTrue(testDirectoryOptional2.isPresent(), "Test directory not found with path ending in a slash");
     }
 
     @Test

--- a/src/test/java/jbash/ShellTests.java
+++ b/src/test/java/jbash/ShellTests.java
@@ -48,15 +48,7 @@ public class ShellTests {
         @ParameterizedTest
         @MethodSource
         public void testSingleQuotesBasic(String name, String command, Object expected) {
-            test(command, expected);
-        }
-
-        @ParameterizedTest
-        @MethodSource
-        public void testSingleQuotesEscapes(String name, String command, Object expected) {
-            test(command, expected);
-        }
-
+            test(command, expected); }
         public static Stream<Arguments> testSingleQuotesBasic() {
             return Stream.of(
                     Arguments.of(
@@ -82,6 +74,11 @@ public class ShellTests {
             );
         }
 
+
+        @ParameterizedTest
+        @MethodSource
+        public void testSingleQuotesEscapes(String name, String command, Object expected) {
+            test(command, expected); }
         public static Stream<Arguments> testSingleQuotesEscapes() {
             return Stream.of(
                     Arguments.of(
@@ -104,11 +101,9 @@ public class ShellTests {
     class DoubleQuotes {
         @ParameterizedTest
         @MethodSource
-        public void testDoubleQuotes(String name, String command, Object expected) {
-            test(command, expected);
-        }
-
-        public static Stream<Arguments> testDoubleQuotes() {
+        public void testDoubleQuotesBasic(String name, String command, Object expected) {
+            test(command, expected); }
+        public static Stream<Arguments> testDoubleQuotesBasic() {
             return Stream.of(
                     Arguments.of(
                             "Double Quotes Basic",
@@ -123,27 +118,46 @@ public class ShellTests {
                             "\"april\" and \"may\"",
                             List.of("april", "and", "may")),
                     Arguments.of(
-                            "Double Quotes Concatenation",
-                            "\"april\"and\"may\"",
-                            List.of("aprilandmay")),
-                    Arguments.of(
-                            "Double Quotes Concatenation",
-                            "\"april\"and\"may\"",
-                            List.of("aprilandmay")),
-                    Arguments.of(
                             "Double Quotes with Single Quotes",
                             "\"april, or could it be 'may'?\"",
                             List.of("april, or could it be 'may'?")),
                     Arguments.of(
                             "Single Double Quote",
                             "\"\nApril\"",
-                            List.of("April")),
+                            List.of("April"))
+            );
+        }
 
-                    /* POSIX TEST (2.2.3):
-                    The <backslash> shall retain its special meaning as an escape character,
-                    only when followed by one of the following characters when considered special:
-                        $   `   "   \   <newline>
-                    */
+
+        @ParameterizedTest
+        @MethodSource
+        public void testDoubleQuotesConcatenation(String name, String command, Object expected) {
+            test(command, expected); }
+        public static Stream<Arguments> testDoubleQuotesConcatenation() {
+            return Stream.of(
+                    Arguments.of(
+                            "Double Quotes Concatenation",
+                            "\"april\"and\"may\"",
+                            List.of("aprilandmay")),
+                    Arguments.of(
+                            "Double Quotes Concatenation",
+                            "\"april\"and\"may\"",
+                            List.of("aprilandmay"))
+            );
+        }
+
+
+        /* POSIX TEST (2.2.3):
+            The <backslash> shall retain its special meaning as an escape character,
+            only when followed by one of the following characters when considered special:
+                $   `   "   \   <newline>
+        */
+        @ParameterizedTest
+        @MethodSource
+        public void testDoubleQuotesEscapes(String name, String command, Object expected) {
+            test(command, expected); }
+        public static Stream<Arguments> testDoubleQuotesEscapes() {
+            return Stream.of(
                     Arguments.of(
                             "Double Quotes Escaped Dollar",
                             "\"\\$EAL\"",
@@ -163,7 +177,7 @@ public class ShellTests {
                     Arguments.of(
                             "Double Quotes Escaped Newline",
                             "\"april and...\\\nmay\"",  // "april and...\
-                                                        // may"
+                            // may"
                             List.of("april and...may")),
                     Arguments.of(
                             "Double Quotes Only Aforementioned Characters",

--- a/src/test/java/jbash/ShellTests.java
+++ b/src/test/java/jbash/ShellTests.java
@@ -119,8 +119,8 @@ public class ShellTests {
                             List.of("april", "and", "may")),
                     Arguments.of(
                             "Double Quotes with Single Quotes",
-                            "\"april, or could it be 'may'?\"",
-                            List.of("april, or could it be 'may'?")),
+                            "\"april's showers bring may flowers\"",
+                            List.of("april's showers bring may flowers")),
                     Arguments.of(
                             "Single Double Quote",
                             "\"\nApril\"",

--- a/src/test/java/jbash/ShellTests.java
+++ b/src/test/java/jbash/ShellTests.java
@@ -84,7 +84,7 @@ public class ShellTests {
                     Arguments.of(
                             "Single Quotes Escapes",  // Single quotes do not support escaping!
                             "'apr\\'il",  // 'apr\'il
-                            List.of("april")),
+                            List.of("apr\\il")),
                     Arguments.of(
                             "Single Quotes Escapes II",
                             "'april\\june'",


### PR DESCRIPTION
Adds a rudimentary parser to JBash, certainly better than the original string-splitting algorithm we had previously.

## Notable features
- Quoting is implemented, through single, double, and backslash. These will allow you to represent certain special characters as themselves.
- Tokenization for certain special characters and sequences has been implemented, though their use-cases have yet to be implemented. 

## Limitations
- The parser needs to be made more robust to allow for multiple-line sequences of input.
- Certain notable expansions have yet to be implemented. For example, `"Hello $planet"` will just output `Hello $planet` -- it will not look for the "planet" environment variable and substitute.