### PR TITLE
Adds new command method err for standard error messages, fixes ls

### DIFF
--- a/src/main/java/jbash/commands/CmdCd.java
+++ b/src/main/java/jbash/commands/CmdCd.java
@@ -16,14 +16,14 @@ class CmdCd extends Command {
 
     @Override
     public int execute(List<String> argv) {
-        if (argv.size() > 1) { cmdErrln("cd: too many arguments"); return 1; }
+        if (argv.size() > 1) { err("too many arguments"); return 1; }
         if (argv.isEmpty()) {
             FileSystemAPI.getInstance().moveCurrentDirectory("");
             return 0;
         }
         if (FileSystemAPI.getInstance().moveCurrentDirectory(argv.getFirst())) { return 0; }
-        // TODO: Add explicit error messaging
-        cmdErrln("cd: cringe bro");
+        // FIXME: I'm not sure what other error messages there are but surely there's more than this
+        err("No such file or directory");
         return 1;
     }
 }

--- a/src/main/java/jbash/commands/CmdLs.java
+++ b/src/main/java/jbash/commands/CmdLs.java
@@ -33,16 +33,17 @@ class CmdLs extends Command {
             if (argv.size() > 1) { multiplePaths = true; }
             for (String path : argv) {
                 Optional<FileSystemObject> directory = FSAPI.getFileSystemObject(path);
-                if (directory.isEmpty()) { cmdErrln("ls: cannot access '" + path + "': No such file or directory"); }
+                if (directory.isEmpty()) { err("cannot access '" + path + "': No such file or directory"); }
                 else if (!(directory.get() instanceof Directory)) { cmdPrintln(directory.get().getName()); }
                 else {
                     List<FileSystemObject> children = ((Directory) directory.get()).getChildren();
-                    if (multiplePaths) { System.out.println(path + ":"); }
+                    if (multiplePaths) { cmdPrintln(path + ":"); }
                     for (FileSystemObject child : children) {
                         cmdPrint(child.getName());
                         cmdPrint(" ");
                     }
                     cmdPrintln();
+                    if (multiplePaths) { cmdPrintln(); }
                 }
             }
         }

--- a/src/main/java/jbash/commands/CmdMkdir.java
+++ b/src/main/java/jbash/commands/CmdMkdir.java
@@ -17,13 +17,13 @@ class CmdMkdir extends Command {
     @Override
     public int execute(List<String> argv) {
         if (argv.isEmpty()) {
-            cmdErrln("mkdir: missing operand");
+            err("missing operand");
             cmdErrln("Try 'mkdir --help' for more information." );
         }
         FileSystemAPI FSAPI = FileSystemAPI.getInstance();
         for (String arg : argv) {
             if (!FSAPI.createDirectory(arg)) {
-                cmdErrln("mkdir: cannot create directory '" + arg + "'");
+                err("cannot create directory '" + arg +"'");
             }
         }
         return 0;

--- a/src/main/java/jbash/commands/Command.java
+++ b/src/main/java/jbash/commands/Command.java
@@ -63,4 +63,8 @@ abstract class Command {
 
     public abstract String getHelp();
     public abstract int execute(List<String> argv);
+
+    public void err(String errorMessage) {
+        cmdErrln(name + ": " + errorMessage);
+    }
 }


### PR DESCRIPTION
This pull request adds a new method `err`, that wraps CmdErr and can be used to print standardized error message for each command. Additionally, ls was broken in the previous pr, one instance of System.out.write was missed and not replaced with the new CmdPrint.