### PR TITLE
Change failed commands to all return -1, PWD

### DIFF
--- a/src/main/java/jbash/commands/CmdCd.java
+++ b/src/main/java/jbash/commands/CmdCd.java
@@ -16,7 +16,7 @@ class CmdCd extends Command {
 
     @Override
     public int execute(List<String> argv) {
-        if (argv.size() > 1) { err("too many arguments"); return 1; }
+        if (argv.size() > 1) { err("too many arguments"); return -1; }
         if (argv.isEmpty()) {
             FileSystemAPI.getInstance().moveCurrentDirectory("");
             return 0;
@@ -24,6 +24,6 @@ class CmdCd extends Command {
         if (FileSystemAPI.getInstance().moveCurrentDirectory(argv.getFirst())) { return 0; }
         // FIXME: I'm not sure what other error messages there are but surely there's more than this
         err("No such file or directory");
-        return 1;
+        return -1;
     }
 }

--- a/src/main/java/jbash/commands/CmdMkdir.java
+++ b/src/main/java/jbash/commands/CmdMkdir.java
@@ -19,11 +19,13 @@ class CmdMkdir extends Command {
         if (argv.isEmpty()) {
             err("missing operand");
             cmdErrln("Try 'mkdir --help' for more information." );
+            return -1;
         }
         FileSystemAPI FSAPI = FileSystemAPI.getInstance();
         for (String arg : argv) {
             if (!FSAPI.createDirectory(arg)) {
                 err("cannot create directory '" + arg +"'");
+                return -1;
             }
         }
         return 0;

--- a/src/main/java/jbash/commands/CmdPwd.java
+++ b/src/main/java/jbash/commands/CmdPwd.java
@@ -19,9 +19,9 @@ class CmdPwd extends Command {
 
     @Override
     public int execute(List<String> argv) {
-        Optional<FileSystemObject> currentDirectoryOptional = FileSystemAPI.getInstance().getFileSystemObject("./");
-        if (currentDirectoryOptional.isEmpty() || !(currentDirectoryOptional.get() instanceof Directory currentDirectory)) { cmdErrln("ERROR: I HAVE NO IDEA WHAT HAPPENED"); return 1; }
-        cmdPrintln(currentDirectory.getPath());
+        Optional<Directory> currentDirectoryOptional = FileSystemAPI.getInstance().getFileSystemDirectory("./");
+        if (currentDirectoryOptional.isEmpty()) { err("I don't think this is reachable?"); return 1; }
+        cmdPrintln(currentDirectoryOptional.get().getPath());
         return 0;
     }
 }


### PR DESCRIPTION
All failed commands now correctly return -1, if applicable. PWD has also been modified to make use of the new `getFileSystemDirectory` function.